### PR TITLE
Set memory after asking

### DIFF
--- a/lib/kontena/plugin/vagrant/nodes/create_command.rb
+++ b/lib/kontena/plugin/vagrant/nodes/create_command.rb
@@ -27,7 +27,7 @@ module Kontena::Plugin::Vagrant::Nodes
           grid: current_grid,
           name: name,
           instance_number: i + 1,
-          memory: memory,
+          memory: instance_memory,
           version: version,
           coreos_channel: coreos_channel
         )


### PR DESCRIPTION
Prompting changes introduced a regression for setting the memory on a node. Prompter asks the memory but still uses only the option given in cmd. Fixes #21 
