### PR TITLE
Fix vagrant master create --name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in kontena-plugin-aws.gemspec
+# Specify your gem's dependencies in kontena-plugin-vagrant.gemspec
 gemspec
 
 group :development do

--- a/lib/kontena/machine/vagrant/master_provisioner.rb
+++ b/lib/kontena/machine/vagrant/master_provisioner.rb
@@ -20,7 +20,7 @@ module Kontena
         end
 
         def run!(opts)
-          name = generate_name
+          name = opts[:name] || generate_name
           version = opts[:version]
           memory = opts[:memory] || 1024
           vault_secret = opts[:vault_secret]

--- a/lib/kontena/plugin/vagrant/master/create_command.rb
+++ b/lib/kontena/plugin/vagrant/master/create_command.rb
@@ -15,6 +15,7 @@ module Kontena::Plugin::Vagrant::Master
       require_relative '../../../machine/vagrant'
       mem = ask_instance_memory
       provisioner.run!(
+        name: name,
         memory: mem,
         version: version,
         vault_secret: vault_secret || SecureRandom.hex(24),

--- a/lib/kontena/plugin/vagrant/master/create_command.rb
+++ b/lib/kontena/plugin/vagrant/master/create_command.rb
@@ -4,12 +4,11 @@ module Kontena::Plugin::Vagrant::Master
   class CreateCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    option "--name", "[NAME]", "Set master name"
+    option "--name", "NAME", "Set master name"
     option "--memory", "MEMORY", "How much memory node has"
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
     option "--vault-secret", "VAULT_SECRET", "Secret key for Vault"
     option "--vault-iv", "VAULT_IV", "Initialization vector for Vault"
-    option "--name", "NAME", "Set Master name"
     option "--coreos-channel", "CHANNEL", "CoreOS release channel", default: 'stable'
 
     def execute

--- a/spec/kontena/plugin/vagrant/master/create_command_spec.rb
+++ b/spec/kontena/plugin/vagrant/master/create_command_spec.rb
@@ -15,13 +15,14 @@ describe Kontena::Plugin::Vagrant::Master::CreateCommand do
 
     it 'passes options to provisioner' do
       options = [
+        '--name', 'my-custom-name',
         '--memory', '1024',
         '--no-prompt',
         '--skip-auth-provider'
       ]
       expect(subject).to receive(:provisioner).and_return(provisioner)
       expect(provisioner).to receive(:run!).with(
-        hash_including(memory: '1024')
+        hash_including(memory: '1024', name: 'my-custom-name')
       )
       subject.run(options)
     end


### PR DESCRIPTION
This PR fixes some problems of the `--name` option of the `kontena vagrant master create` command.