### PR TITLE
Update ruby versions to match main cli in travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - 2.0.0-p648
-  - 2.1.8
-  - 2.2.3
-  - 2.3.1
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.1
 before_install:
   - rvm @global do gem uninstall bundler -a -x
   - rvm @global do gem install bundler -v 1.12.5


### PR DESCRIPTION
Makes sense to match same Ruby versions in build that main CLI uses. Also the 2.0.0-p648 caused some failing builds since main cli uses liquid templating which requires >2.1 Ruby.