### PR TITLE
Improve error handling and output

### DIFF
--- a/lib/kontena/machine/vagrant/common.rb
+++ b/lib/kontena/machine/vagrant/common.rb
@@ -1,0 +1,37 @@
+require 'fileutils'
+require 'erb'
+require 'open3'
+require 'json'
+
+module Kontena
+  module Machine
+    module Vagrant
+      module Common
+
+        def erb(template, vars)
+          ERB.new(template).result(OpenStruct.new(vars).instance_eval { binding })
+        end
+
+        def run_command(cmd)
+          exit_code = 0
+          Open3.popen3(cmd) do |stdin, stdout, stderr, wait|
+            outputs = []
+            outputs << Thread.new {
+              while o = stdout.gets
+                $stdout << o
+              end
+            }
+            outputs << Thread.new {
+              while o = stderr.gets
+                $stderr << o
+              end
+            }
+            exit_code = wait.value.exitstatus
+            outputs.each(&:kill)
+          end
+          exit exit_code if exit_code != 0
+        end
+      end
+    end
+  end
+end

--- a/lib/kontena/machine/vagrant/common.rb
+++ b/lib/kontena/machine/vagrant/common.rb
@@ -13,22 +13,8 @@ module Kontena
         end
 
         def run_command(cmd)
-          exit_code = 0
-          Open3.popen3(cmd) do |stdin, stdout, stderr, wait|
-            outputs = []
-            outputs << Thread.new {
-              while o = stdout.gets
-                $stdout << o
-              end
-            }
-            outputs << Thread.new {
-              while o = stderr.gets
-                $stderr << o
-              end
-            }
-            exit_code = wait.value.exitstatus
-            outputs.each(&:kill)
-          end
+          system(cmd)
+          exit_code = $?
           exit exit_code if exit_code != 0
         end
       end

--- a/lib/kontena/machine/vagrant/common.rb
+++ b/lib/kontena/machine/vagrant/common.rb
@@ -13,9 +13,7 @@ module Kontena
         end
 
         def run_command(cmd)
-          system(cmd)
-          exit_code = $?
-          exit exit_code if exit_code != 0
+          exit $?.exitstatus unless system(cmd)
         end
       end
     end

--- a/lib/kontena/machine/vagrant/master_destroyer.rb
+++ b/lib/kontena/machine/vagrant/master_destroyer.rb
@@ -1,25 +1,18 @@
-require 'fileutils'
+require_relative 'common'
 
 module Kontena
   module Machine
     module Vagrant
       class MasterDestroyer
-
+        include Kontena::Machine::Vagrant::Common
         include Kontena::Cli::ShellSpinner
 
         def run!
           vagrant_path = "#{Dir.home}/.kontena/vagrant_master"
           Dir.chdir(vagrant_path) do
-            spinner "Terminating Kontena Master from Vagrant " do
-              Open3.popen2('vagrant destroy -f') do |stdin, output, wait|
-                while o = output.gets
-                  puts o if ENV['DEBUG']
-                end
-                if wait.value == 0
-                  FileUtils.remove_entry_secure(vagrant_path)
-                end
-              end
-            end
+            spinner "Triggering termination of Kontena Master from Vagrant"
+            run_command('vagrant destroy -f')
+            FileUtils.remove_entry_secure(vagrant_path)
           end
         end
       end

--- a/lib/kontena/plugin/vagrant/master/restart_command.rb
+++ b/lib/kontena/plugin/vagrant/master/restart_command.rb
@@ -9,9 +9,7 @@ module Kontena::Plugin::Vagrant::Master
       abort("Cannot find Vagrant kontena-master".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Executing 'vagrant reload' for kontena-master"
-        system('vagrant reload')
-        exit_code = $?
-        exit exit_code if exit_code != 0
+        exit $?.exitstatus unless system('vagrant reload')
         spinner "Vagrant machine restarted"
       end
     end

--- a/lib/kontena/plugin/vagrant/master/restart_command.rb
+++ b/lib/kontena/plugin/vagrant/master/restart_command.rb
@@ -4,17 +4,20 @@ module Kontena::Plugin::Vagrant::Master
 
     def execute
       require_relative '../../../machine/vagrant'
-      
+
       vagrant_path = "#{Dir.home}/.kontena/vagrant_master"
       abort("Cannot find Vagrant kontena-master".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
-        spinner "Restarting Vagrant kontena-master " do
-          Open3.popen2('vagrant reload') do |stdin, output, wait|
-            while o = output.gets
-              print o if ENV['DEBUG']
-            end
+        spinner "Executing 'vagrant reload'"
+        Open3.popen2('vagrant reload') do |stdin, output, wait|
+          while o = output.gets
+            $stdout << o
           end
+          exit_code = wait.value.exitstatus
+          exit exit_code if exit_code != 0
         end
+
+        spinner "Vagrant machine restarted"
       end
     end
   end

--- a/lib/kontena/plugin/vagrant/master/restart_command.rb
+++ b/lib/kontena/plugin/vagrant/master/restart_command.rb
@@ -9,14 +9,9 @@ module Kontena::Plugin::Vagrant::Master
       abort("Cannot find Vagrant kontena-master".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Executing 'vagrant reload' for kontena-master"
-        Open3.popen2('vagrant reload') do |stdin, output, wait|
-          while o = output.gets
-            $stdout << o
-          end
-          exit_code = wait.value.exitstatus
-          exit exit_code if exit_code != 0
-        end
-
+        system('vagrant reload')
+        exit_code = $?
+        exit exit_code if exit_code != 0
         spinner "Vagrant machine restarted"
       end
     end

--- a/lib/kontena/plugin/vagrant/master/restart_command.rb
+++ b/lib/kontena/plugin/vagrant/master/restart_command.rb
@@ -8,7 +8,7 @@ module Kontena::Plugin::Vagrant::Master
       vagrant_path = "#{Dir.home}/.kontena/vagrant_master"
       abort("Cannot find Vagrant kontena-master".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
-        spinner "Executing 'vagrant reload'"
+        spinner "Executing 'vagrant reload' for kontena-master"
         Open3.popen2('vagrant reload') do |stdin, output, wait|
           while o = output.gets
             $stdout << o

--- a/lib/kontena/plugin/vagrant/master/start_command.rb
+++ b/lib/kontena/plugin/vagrant/master/start_command.rb
@@ -9,11 +9,9 @@ module Kontena::Plugin::Vagrant::Master
       abort("Cannot find Vagrant node kontena-master".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Triggering 'vagrant up' for kontena-master"
-        Open3.popen2('vagrant up') do |stdin, output, wait|
-          while o = output.gets
-            $stdout << o
-          end
-        end
+        system('vagrant up')
+        exit_code = $?
+        exit exit_code if exit_code != 0
       end
     end
   end

--- a/lib/kontena/plugin/vagrant/master/start_command.rb
+++ b/lib/kontena/plugin/vagrant/master/start_command.rb
@@ -9,9 +9,7 @@ module Kontena::Plugin::Vagrant::Master
       abort("Cannot find Vagrant node kontena-master".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Triggering 'vagrant up' for kontena-master"
-        system('vagrant up')
-        exit_code = $?
-        exit exit_code if exit_code != 0
+        exit $?.exitstatus unless system('vagrant up')
       end
     end
   end

--- a/lib/kontena/plugin/vagrant/master/start_command.rb
+++ b/lib/kontena/plugin/vagrant/master/start_command.rb
@@ -4,15 +4,14 @@ module Kontena::Plugin::Vagrant::Master
 
     def execute
       require_relative '../../../machine/vagrant'
-      
+
       vagrant_path = "#{Dir.home}/.kontena/vagrant_master"
       abort("Cannot find Vagrant node kontena-master".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
-        spinner "Starting Vagrant machine kontena-master " do
-          Open3.popen2('vagrant up') do |stdin, output, wait|
-            while o = output.gets
-              print o if ENV['DEBUG']
-            end
+        spinner "Triggering 'vagrant up' for kontena-master"
+        Open3.popen2('vagrant up') do |stdin, output, wait|
+          while o = output.gets
+            $stdout << o
           end
         end
       end

--- a/lib/kontena/plugin/vagrant/master/stop_command.rb
+++ b/lib/kontena/plugin/vagrant/master/stop_command.rb
@@ -9,9 +9,7 @@ module Kontena::Plugin::Vagrant::Master
       abort("Cannot find Vagrant kontena-master".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Triggering 'vagrant halt' for kontena-master"
-        system('vagrant halt')
-        exit_code = $?
-        exit exit_code if exit_code != 0
+        exit $?.exitstatus unless system('vagrant halt')
       end
     end
   end

--- a/lib/kontena/plugin/vagrant/master/stop_command.rb
+++ b/lib/kontena/plugin/vagrant/master/stop_command.rb
@@ -4,15 +4,14 @@ module Kontena::Plugin::Vagrant::Master
 
     def execute
       require_relative '../../../machine/vagrant'
-      
+
       vagrant_path = "#{Dir.home}/.kontena/vagrant_master"
       abort("Cannot find Vagrant kontena-master".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
-        spinner "Stopping Vagrant kontena-master " do
-          Open3.popen2('vagrant halt') do |stdin, output, wait|
-            while o = output.gets
-              print o if ENV['DEBUG']
-            end
+        spinner "Triggering 'vagrant halt' for kontena-master"
+        Open3.popen2('vagrant halt') do |stdin, output, wait|
+          while o = output.gets
+            $stdout << o
           end
         end
       end

--- a/lib/kontena/plugin/vagrant/master/stop_command.rb
+++ b/lib/kontena/plugin/vagrant/master/stop_command.rb
@@ -9,11 +9,9 @@ module Kontena::Plugin::Vagrant::Master
       abort("Cannot find Vagrant kontena-master".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Triggering 'vagrant halt' for kontena-master"
-        Open3.popen2('vagrant halt') do |stdin, output, wait|
-          while o = output.gets
-            $stdout << o
-          end
-        end
+        system('vagrant halt')
+        exit_code = $?
+        exit exit_code if exit_code != 0
       end
     end
   end

--- a/lib/kontena/plugin/vagrant/nodes/restart_command.rb
+++ b/lib/kontena/plugin/vagrant/nodes/restart_command.rb
@@ -15,9 +15,7 @@ module Kontena::Plugin::Vagrant::Nodes
       abort("Cannot find Vagrant node #{name}".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Triggering 'vagrant reload' for #{name.colorize(:cyan)}"
-        system('vagrant reload')
-        exit_code = $?
-        exit exit_code if exit_code != 0
+        exit $?.exitstatus unless system('vagrant reload')
       end
     end
   end

--- a/lib/kontena/plugin/vagrant/nodes/restart_command.rb
+++ b/lib/kontena/plugin/vagrant/nodes/restart_command.rb
@@ -14,11 +14,10 @@ module Kontena::Plugin::Vagrant::Nodes
       vagrant_path = "#{Dir.home}/.kontena/#{current_grid}/#{name}"
       abort("Cannot find Vagrant node #{name}".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
-        spinner "Restarting Vagrant machine #{name.colorize(:cyan)} " do
-          Open3.popen2('vagrant reload') do |stdin, output, wait|
-            while o = output.gets
-              print o if ENV['DEBUG']
-            end
+        spinner "Triggering 'vagrant reload' for #{name.colorize(:cyan)}"
+        Open3.popen2('vagrant reload') do |stdin, output, wait|
+          while o = output.gets
+            $stdout << o
           end
         end
       end

--- a/lib/kontena/plugin/vagrant/nodes/restart_command.rb
+++ b/lib/kontena/plugin/vagrant/nodes/restart_command.rb
@@ -15,11 +15,9 @@ module Kontena::Plugin::Vagrant::Nodes
       abort("Cannot find Vagrant node #{name}".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Triggering 'vagrant reload' for #{name.colorize(:cyan)}"
-        Open3.popen2('vagrant reload') do |stdin, output, wait|
-          while o = output.gets
-            $stdout << o
-          end
-        end
+        system('vagrant reload')
+        exit_code = $?
+        exit exit_code if exit_code != 0
       end
     end
   end

--- a/lib/kontena/plugin/vagrant/nodes/start_command.rb
+++ b/lib/kontena/plugin/vagrant/nodes/start_command.rb
@@ -15,11 +15,9 @@ module Kontena::Plugin::Vagrant::Nodes
       abort("Cannot find Vagrant node #{name}".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Triggering 'vagrant up' for #{name.colorize(:cyan)}"
-        Open3.popen2('vagrant up') do |stdin, output, wait|
-          while o = output.gets
-            $stdout << o
-          end
-        end
+        system('vagrant up')
+        exit_code = $?
+        exit exit_code if exit_code != 0
       end
     end
   end

--- a/lib/kontena/plugin/vagrant/nodes/start_command.rb
+++ b/lib/kontena/plugin/vagrant/nodes/start_command.rb
@@ -15,9 +15,7 @@ module Kontena::Plugin::Vagrant::Nodes
       abort("Cannot find Vagrant node #{name}".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Triggering 'vagrant up' for #{name.colorize(:cyan)}"
-        system('vagrant up')
-        exit_code = $?
-        exit exit_code if exit_code != 0
+        exit $?.exitstatus unless system('vagrant up')
       end
     end
   end

--- a/lib/kontena/plugin/vagrant/nodes/start_command.rb
+++ b/lib/kontena/plugin/vagrant/nodes/start_command.rb
@@ -10,15 +10,14 @@ module Kontena::Plugin::Vagrant::Nodes
       require_current_grid
 
       require_relative '../../../machine/vagrant'
-      
+
       vagrant_path = "#{Dir.home}/.kontena/#{current_grid}/#{name}"
       abort("Cannot find Vagrant node #{name}".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
-        spinner "Starting Vagrant machine #{name.colorize(:cyan)} " do
-          Open3.popen2('vagrant up') do |stdin, output, wait|
-            while o = output.gets
-              print o if ENV['DEBUG']
-            end
+        spinner "Triggering 'vagrant up' for #{name.colorize(:cyan)}"
+        Open3.popen2('vagrant up') do |stdin, output, wait|
+          while o = output.gets
+            $stdout << o
           end
         end
       end

--- a/lib/kontena/plugin/vagrant/nodes/stop_command.rb
+++ b/lib/kontena/plugin/vagrant/nodes/stop_command.rb
@@ -15,11 +15,9 @@ module Kontena::Plugin::Vagrant::Nodes
       abort("Cannot find Vagrant node #{name}".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Triggering 'vagrant halt' for #{name.colorize(:cyan)}"
-        Open3.popen2('vagrant halt') do |stdin, output, wait|
-          while o = output.gets
-            $stdout << o
-          end
-        end
+        system('vagrant halt')
+        exit_code = $?
+        exit exit_code if exit_code != 0
       end
     end
   end

--- a/lib/kontena/plugin/vagrant/nodes/stop_command.rb
+++ b/lib/kontena/plugin/vagrant/nodes/stop_command.rb
@@ -10,17 +10,16 @@ module Kontena::Plugin::Vagrant::Nodes
       require_current_grid
 
       require_relative '../../../machine/vagrant'
-      
+
       vagrant_path = "#{Dir.home}/.kontena/#{current_grid}/#{name}"
       abort("Cannot find Vagrant node #{name}".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
-          spinner "Stopping Vagrant machine #{name.colorize(:cyan)} " do
-            Open3.popen2('vagrant halt') do |stdin, output, wait|
-              while o = output.gets
-                print o if ENV['DEBUG']
-              end
-            end
+        spinner "Triggering 'vagrant halt' for #{name.colorize(:cyan)}"
+        Open3.popen2('vagrant halt') do |stdin, output, wait|
+          while o = output.gets
+            $stdout << o
           end
+        end
       end
     end
   end

--- a/lib/kontena/plugin/vagrant/nodes/stop_command.rb
+++ b/lib/kontena/plugin/vagrant/nodes/stop_command.rb
@@ -15,9 +15,7 @@ module Kontena::Plugin::Vagrant::Nodes
       abort("Cannot find Vagrant node #{name}".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
         spinner "Triggering 'vagrant halt' for #{name.colorize(:cyan)}"
-        system('vagrant halt')
-        exit_code = $?
-        exit exit_code if exit_code != 0
+        exit $?.exitstatus unless system('vagrant halt')
       end
     end
   end


### PR DESCRIPTION
Shows vagrant output by default and exits early on error when creating a vagrant box.

Example:
```
$ kontena vagrant master create
 _               _
| | _____  _ __ | |_ ___ _ __   __ _
| |/ / _ \| '_ \| __/ _ \ '_ \ / _` |
|   < (_) | | | | ||  __/ | | | (_| |
|_|\_\___/|_| |_|\__\___|_| |_|\__,_|
-------------------------------------
Kontena CLI (c) 2017 Kontena, Inc.
> Enter a name for this Kontena Master:  vagrant
> Select OAuth2 authentication provider:  None (single user mode)

You have selected to use Kontena Master in single user mode. You can configure an authentication provider later. For more information, see here: www.kontena.io/docs/using-kontena/authentication

> Choose a size 512MB
 [done] Creating Vagrant config      
 [done] Triggering CoreOS Container Linux box update
==> vagrant: Checking for updates to 'coreos-stable'
    vagrant: Latest installed version: 1353.8.0
    vagrant: Version constraints: 
    vagrant: Provider: virtualbox
==> vagrant: Box 'coreos-stable' (v1353.8.0) is running the latest version.
 [done] Executing 'vagrant up'
Bringing machine 'vagrant' up with 'virtualbox' provider...
==> vagrant: Importing base box 'coreos-stable'...
==> vagrant: Matching MAC address for NAT networking...
==> vagrant: Checking if box 'coreos-stable' is up to date...
==> vagrant: Setting the name of the VM: vagrant
==> vagrant: Clearing any previously set network interfaces...
==> vagrant: Preparing network interfaces based on configuration...
    vagrant: Adapter 1: nat
    vagrant: Adapter 2: hostonly
==> vagrant: Forwarding ports...
    vagrant: 22 (guest) => 2222 (host) (adapter 1)
==> vagrant: Running 'pre-boot' VM customizations...
==> vagrant: Booting VM...
==> vagrant: Waiting for machine to boot. This may take a few minutes...
    vagrant: SSH address: 127.0.0.1:2222
    vagrant: SSH username: core
    vagrant: SSH auth method: private key
==> vagrant: Machine booted and ready!
==> vagrant: Setting hostname...
==> vagrant: Configuring and enabling network interfaces...
==> vagrant: Running provisioner: file...
==> vagrant: Running provisioner: shell...
    vagrant: Running: inline script
 [done] 'vagrant up' executed successfully
 [done] Waiting for vagrant to start      
 [done] Retrieving vagrant version     
 [done] Kontena Master  is now running at http://192.168.66.100:8080
 [done] Exchanging authorization code for an access token from Kontena Master     
 [done] Creating test grid      
 [done] Switching scope to test grid      
 [done] Setting Master configuration server.provider to 'vagrant'     
```
Fixes #7 #25 