### PR TITLE
Allow node IPs to be specified

### DIFF
--- a/lib/kontena/machine/vagrant/Vagrantfile.node.rb.erb
+++ b/lib/kontena/machine/vagrant/Vagrantfile.node.rb.erb
@@ -17,7 +17,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define "<%= name %>" do |docker|
     docker.vm.box = "coreos-<%= coreos_channel %>"
     docker.vm.box_url = "http://stable.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json"
+    <% if network_address == "dhcp" %>
     docker.vm.network "private_network", type: "dhcp"
+    <% else  %>
+    docker.vm.network "private_network", ip: "<%= network_address %>"
+    <% end %>
     docker.vm.hostname = "<%= name %>"
     docker.vm.provider "virtualbox" do |vb|
       vb.name = "<%= name %>"

--- a/lib/kontena/machine/vagrant/node_provisioner.rb
+++ b/lib/kontena/machine/vagrant/node_provisioner.rb
@@ -33,6 +33,7 @@ module Kontena
             name: name,
             version: version,
             memory: opts[:memory] || 1024,
+            network_address: opts[:network_address],
             master_uri: opts[:master_uri],
             grid_token: opts[:grid_token],
             coreos_channel: opts[:coreos_channel],

--- a/lib/kontena/plugin/vagrant/nodes/create_command.rb
+++ b/lib/kontena/plugin/vagrant/nodes/create_command.rb
@@ -6,6 +6,7 @@ module Kontena::Plugin::Vagrant::Nodes
     parameter "[NAME]", "Node name"
     option "--instances", "AMOUNT", "How many nodes will be created"
     option "--memory", "MEMORY", "How much memory node has"
+    option "--network-address", "IP", "First IP address for the node(s)", default: 'dhcp'
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
     option "--coreos-channel", "CHANNEL", "CoreOS release channel", default: 'stable'
 
@@ -20,6 +21,14 @@ module Kontena::Plugin::Vagrant::Nodes
 
       grid = fetch_grid
       provisioner = provisioner(client(require_token))
+
+      require 'ipaddr'
+      ip_address = if network_address == "dhcp"
+        nil
+      else
+        IPAddr.new network_address
+      end
+
       instance_count.to_i.times do |i|
         provisioner.run!(
           master_uri: api_url,
@@ -27,10 +36,13 @@ module Kontena::Plugin::Vagrant::Nodes
           grid: current_grid,
           name: name,
           instance_number: i + 1,
+          network_address: ip_address ? ip_address.to_s : "dhcp",
           memory: instance_memory,
           version: version,
           coreos_channel: coreos_channel
         )
+
+        ip_address = ip_address.succ if ip_address
       end
     end
 


### PR DESCRIPTION
Adds `--network-address` that sets the IP for the node. If --instances is greater than 1, then ip_addr.succ is used.

```
node-1 --> 192.168.66.101
node-2 --> 192.168.66.102
node-3 --> 192.168.66.103
```